### PR TITLE
ZeresPluginLibrary update

### DIFF
--- a/hashes/50e6e9a7904fbbc55fa6ce366e6ae2dd7908007e2bae7d66b94d65c4717f8c13
+++ b/hashes/50e6e9a7904fbbc55fa6ce366e6ae2dd7908007e2bae7d66b94d65c4717f8c13
@@ -1,0 +1,4 @@
+{
+    "type": "Plugin",
+    "name": "ZeresPluginLibrary"
+}


### PR DESCRIPTION
ZeresPluginLibrary update again

Maybe it's worth removing today's previous version ?
`hashes/6cebef387937ca9ee9c5041137dded7013cff57d7899e671e8a56267d2bf786c `